### PR TITLE
Fix: Frontend port number

### DIFF
--- a/wearhouse/frontend/README.md
+++ b/wearhouse/frontend/README.md
@@ -9,7 +9,8 @@ In the project directory, you can run:
 ### `npm start`
 
 Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
+Open [http://localhost:3006](http://localhost:3006) to view it in your browser.
+
 
 The page will reload when you make changes.\
 You may also see any lint errors in the console.

--- a/wearhouse/frontend/package.json
+++ b/wearhouse/frontend/package.json
@@ -13,7 +13,7 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "set PORT=3006 && react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
Changes the default port number for the frontend development server from 3000 to 3006.

Why is this change needed?
To avoid conflicts with other apps running on port 3000 and maintain consistency across the dev environment.

How to test this change?

Run npm start

The app should open on http://localhost:3006 instead of the default port